### PR TITLE
Add sitemap.xml for site indexing

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://qr-genny.cbuurman.nl/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://qr-genny.cbuurman.nl/legal</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+</urlset> 


### PR DESCRIPTION
Introduces a sitemap.xml file in the public directory to improve search engine indexing. The sitemap includes the homepage and legal page with specified change frequencies and priorities.