### PR TITLE
Add sitemap URL to robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://qr-genny.cbuurman.nl/sitemap.xml


### PR DESCRIPTION
Included a Sitemap directive in robots.txt to help search engines discover the site's sitemap for improved indexing.