### PR TITLE
28 qr styles

### DIFF
--- a/src/components/StylePage/StyleInputComponent.vue
+++ b/src/components/StylePage/StyleInputComponent.vue
@@ -38,9 +38,13 @@ function updateValue(newValue: string, field?: string) {
     }
   }
 
-  qrData.value.style[props.field] = newValue as DotType;
-
-
+  if (props.field === 'dotStyle') {
+    qrData.value.style.dotStyle = newValue as DotType;
+  } else if (props.field === 'cornerStyle') {
+    qrData.value.style.cornerStyle = newValue as CornerSquareType;
+  } else if (props.field === 'cornerDotStyle') {
+    qrData.value.style.cornerDotStyle = newValue as CornerDotType;
+  }
 }
 
 const currentData = qrData.value.style ? qrData.value.style[props.field] : '';

--- a/src/components/StylePage/StyleInputComponent.vue
+++ b/src/components/StylePage/StyleInputComponent.vue
@@ -51,10 +51,3 @@ const currentData = qrData.value.style ? qrData.value.style[props.field] : '';
   <InputComponent inputType="radio" :unique="props.field" value="type" :options="styleTypes" default="square"
     :prefilled="currentData" @update="updateValue" />
 </template>
-
-<style scoped>
-.row {
-  display: flex;
-  gap: 1rem;
-}
-</style>

--- a/src/components/StylePage/StyleInputComponent.vue
+++ b/src/components/StylePage/StyleInputComponent.vue
@@ -32,9 +32,9 @@ function updateValue(newValue: string, field?: string) {
 
   if (!qrData.value.style) {
     qrData.value.style = {
-      dotStyle: {} as DotType,
-      cornerStyle: {} as CornerSquareType,
-      cornerDotStyle: {} as CornerDotType,
+      dotStyle: 'square' as DotType,
+      cornerStyle: 'square' as CornerSquareType,
+      cornerDotStyle: 'square' as CornerDotType,
     }
   }
 

--- a/src/components/StylePage/StyleInputComponent.vue
+++ b/src/components/StylePage/StyleInputComponent.vue
@@ -1,0 +1,82 @@
+<!--
+  Copyright (C) 2026  Casper Buurman
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<script setup lang="ts">
+import { qrData } from '@/data/qr'
+import InputComponent, { type OptionType } from '@/components/InputComponent.vue';
+import type { CornerDotType, CornerSquareType, DotType } from 'qr-code-styling';
+
+// type DotType = "dots" | "rounded" | "classy" | "classy-rounded" | "square" | "extra-rounded";
+const styletypes: OptionType[] = [
+  {
+    label: 'Square',
+    value: 'square',
+  },
+  {
+    label: 'Dots',
+    value: 'dots',
+  },
+  {
+    label: 'Rounded',
+    value: 'rounded',
+  },
+  {
+    label: 'Classy',
+    value: 'classy',
+  },
+  {
+    label: 'Classy Rounded',
+    value: 'classy-rounded',
+  },
+  {
+    label: 'Extra Rounded',
+    value: 'extra-rounded',
+  },
+]
+
+function updateValue(newValue: string, field?: string) {
+  if (!field) return;
+
+
+  if (!qrData.value.style) {
+    qrData.value.style = {
+      dotStyle: {} as DotType,
+      cornerStyle: {} as CornerSquareType,
+      cornerDotStyle: {} as CornerDotType,
+    }
+  }
+
+  qrData.value.style['dotStyle'] = newValue as DotType;
+
+
+}
+
+const currentData = qrData.value.style ? qrData.value.style['dotStyle'] : {} as DotType;
+
+</script>
+
+<template>
+  <InputComponent inputType="radio" :unique="'dotStyle'" value="type" :options="styletypes" default="square"
+    :prefilled="currentData" @update="updateValue" />
+</template>
+
+<style scoped>
+.row {
+  display: flex;
+  gap: 1rem;
+}
+</style>

--- a/src/components/StylePage/StyleInputComponent.vue
+++ b/src/components/StylePage/StyleInputComponent.vue
@@ -20,33 +20,11 @@ import { qrData } from '@/data/qr'
 import InputComponent, { type OptionType } from '@/components/InputComponent.vue';
 import type { CornerDotType, CornerSquareType, DotType } from 'qr-code-styling';
 
-// type DotType = "dots" | "rounded" | "classy" | "classy-rounded" | "square" | "extra-rounded";
-const styletypes: OptionType[] = [
-  {
-    label: 'Square',
-    value: 'square',
-  },
-  {
-    label: 'Dots',
-    value: 'dots',
-  },
-  {
-    label: 'Rounded',
-    value: 'rounded',
-  },
-  {
-    label: 'Classy',
-    value: 'classy',
-  },
-  {
-    label: 'Classy Rounded',
-    value: 'classy-rounded',
-  },
-  {
-    label: 'Extra Rounded',
-    value: 'extra-rounded',
-  },
-]
+const props = defineProps<{
+  styleTypes: OptionType[]
+
+  field: 'dotStyle' | 'cornerStyle' | 'cornerDotStyle'
+}>()
 
 function updateValue(newValue: string, field?: string) {
   if (!field) return;
@@ -60,17 +38,17 @@ function updateValue(newValue: string, field?: string) {
     }
   }
 
-  qrData.value.style['dotStyle'] = newValue as DotType;
+  qrData.value.style[props.field] = newValue as DotType;
 
 
 }
 
-const currentData = qrData.value.style ? qrData.value.style['dotStyle'] : {} as DotType;
+const currentData = qrData.value.style ? qrData.value.style[props.field] : '';
 
 </script>
 
 <template>
-  <InputComponent inputType="radio" :unique="'dotStyle'" value="type" :options="styletypes" default="square"
+  <InputComponent inputType="radio" :unique="props.field" value="type" :options="styleTypes" default="square"
     :prefilled="currentData" @update="updateValue" />
 </template>
 

--- a/src/data/qr.ts
+++ b/src/data/qr.ts
@@ -148,6 +148,9 @@ function applyUpdates(newData: qrDataType) {
   parseBackgroundColorOptions(newData.colour?.backgroundOptions);
   parseCornerSquareColorOptions(newData.colour?.cornersSquareOptions);
   parseCornerDotColorOptions(newData.colour?.cornersDotOptions);
+
+  parseDotStyleOptions(newData.style?.dotStyle);
+
 }
 
 function parseContent(content: Record<string, string>, type: string) {
@@ -397,4 +400,10 @@ function parseCornerDotColorOptions(colorData: colorType) {
   }
 
   qrOptions.value.cornersDotOptions = data.value;
+}
+
+function parseDotStyleOptions(styleData: DotType) {
+  if (!styleData) return;
+
+  qrOptions.value.dotsOptions.type = styleData;
 }

--- a/src/data/qr.ts
+++ b/src/data/qr.ts
@@ -150,6 +150,8 @@ function applyUpdates(newData: qrDataType) {
   parseCornerDotColorOptions(newData.colour?.cornersDotOptions);
 
   parseDotStyleOptions(newData.style?.dotStyle);
+  parseCornerSquareStyleOptions(newData.style?.cornerStyle);
+  parseCornerDotStyleOptions(newData.style?.cornerDotStyle);
 
 }
 
@@ -406,4 +408,14 @@ function parseDotStyleOptions(styleData: DotType) {
   if (!styleData) return;
 
   qrOptions.value.dotsOptions.type = styleData;
+}
+function parseCornerSquareStyleOptions(styleData: CornerSquareType) {
+  if (!styleData) return;
+
+  qrOptions.value.cornersSquareOptions.type = styleData;
+}
+function parseCornerDotStyleOptions(styleData: CornerDotType) {
+  if (!styleData) return;
+
+  qrOptions.value.cornersDotOptions.type = styleData;
 }

--- a/src/views/StyleView.vue
+++ b/src/views/StyleView.vue
@@ -17,17 +17,58 @@
 
 <script setup lang="ts">
 import ArrowButton from '@/components/ArrowButton.vue';
+import type { OptionType } from '@/components/InputComponent.vue';
 import SettingsLayout from '@/components/SettingsLayout.vue';
 import StyleInputComponent from '@/components/StylePage/StyleInputComponent.vue';
+
+const dotStyleTypes: OptionType[] = [
+  {
+    label: 'Square',
+    value: 'square',
+  },
+  {
+    label: 'Dots',
+    value: 'dots',
+  },
+  {
+    label: 'Rounded',
+    value: 'rounded',
+  },
+  {
+    label: 'Classy',
+    value: 'classy',
+  },
+  {
+    label: 'Classy Rounded',
+    value: 'classy-rounded',
+  },
+  {
+    label: 'Extra Rounded',
+    value: 'extra-rounded',
+  },
+]
+
+const cornerStyleTypes: OptionType[] = [
+  ...dotStyleTypes,
+  {
+    label: 'Circle',
+    value: 'dot',
+  },
+]
 
 </script>
 
 <template>
   <SettingsLayout>
     <template #content>
-      <h2>Style Settings Coming Soon</h2>
+      <h2>Dot Style</h2>
+      <StyleInputComponent :styleTypes="dotStyleTypes" field="dotStyle" />
 
-      <StyleInputComponent />
+      <h2>Corner Style</h2>
+      <StyleInputComponent :styleTypes="cornerStyleTypes" field="cornerStyle" />
+
+      <h2>Corner Dot Style</h2>
+      <StyleInputComponent :styleTypes="cornerStyleTypes" field="cornerDotStyle" />
       <!-- Style settings components go here -->
     </template>
     <template #buttons>

--- a/src/views/StyleView.vue
+++ b/src/views/StyleView.vue
@@ -18,6 +18,7 @@
 <script setup lang="ts">
 import ArrowButton from '@/components/ArrowButton.vue';
 import SettingsLayout from '@/components/SettingsLayout.vue';
+import StyleInputComponent from '@/components/StylePage/StyleInputComponent.vue';
 
 </script>
 
@@ -25,6 +26,8 @@ import SettingsLayout from '@/components/SettingsLayout.vue';
   <SettingsLayout>
     <template #content>
       <h2>Style Settings Coming Soon</h2>
+
+      <StyleInputComponent />
       <!-- Style settings components go here -->
     </template>
     <template #buttons>


### PR DESCRIPTION
This pull request implements the core UI and data handling for customizable QR code style options. It introduces a new `StyleInputComponent` for selecting different QR code styles, updates the `StyleView` to use this component for dot, corner, and corner dot styles, and ensures that selected style options are correctly parsed and applied to the QR code data.

**UI Components for Style Selection:**

* Added new `StyleInputComponent.vue` to encapsulate style option selection, including logic to update the QR code style data and a radio input UI for dot, corner, and corner dot styles.
* Updated `StyleView.vue` to use `StyleInputComponent` for dot, corner, and corner dot style selection, and defined available style options for each.

**Data Handling and Parsing:**

* Modified `applyUpdates` in `qr.ts` to parse and apply style options (`dotStyle`, `cornerStyle`, `cornerDotStyle`) from new data.
* Added parsing functions in `qr.ts` to update QR code options with the selected style types for dots, corner squares, and corner dots.